### PR TITLE
fix: parsing of unscoped single package

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,7 +1,30 @@
-import * as process from 'process'
-import * as cp from 'child_process'
-import * as path from 'path'
+import {extractPublishedPackages} from "../src/extract-published-packages"
 
-test('noop', () => {
-  expect(true).toBeTruthy()
+describe("extractPublishedPackages", () => {
+  test("can parse single unscoped package", () => {
+    const fixture = '🦋  bob-the-bundler@1.8.0-canary-17052a5.0'
+    const result = extractPublishedPackages(fixture)
+    expect(result).toStrictEqual({
+      name: "bob-the-bundler",
+      version: '1.8.0-canary-17052a5.0'
+    })
+  })
+
+  test("can parse scoped monorepo package", () => {
+    const fixture = '🦋  New tag:  @graphql-yoga/common@2.8.1-canary-66a4630.0'
+    const result = extractPublishedPackages(fixture)
+    expect(result).toStrictEqual({
+      name: "@graphql-yoga/common",
+      version: '2.8.1-canary-66a4630.0'
+    })
+  })
+
+  test("can parse unscoped monorepo package", () => {
+    const fixture = '🦋  New tag:  graphql-yoga@2.8.1-canary-66a4630.0'
+    const result = extractPublishedPackages(fixture)
+    expect(result).toStrictEqual({
+      name: "graphql-yoga",
+      version: '2.8.1-canary-66a4630.0'
+    })
+  })
 })

--- a/lib/extract-published-packages.js
+++ b/lib/extract-published-packages.js
@@ -1,0 +1,16 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+function extractPublishedPackages(line) {
+    let newTagRegex = /New tag:\s+(@[^/]+\/[^@]+|[^/]+)@([^\s]+)/;
+    let match = line.match(newTagRegex);
+    if (match === null) {
+        let npmOutRegex = /\+?\s+(@[^/]+\/[^@]+|[^/]+)@([^\s]+)/;
+        match = line.match(npmOutRegex);
+    }
+    if (match) {
+        const [, name, version] = match;
+        return { name, version };
+    }
+    return null;
+}
+exports.extractPublishedPackages = extractPublishedPackages;

--- a/lib/main.js
+++ b/lib/main.js
@@ -20,6 +20,7 @@ const core = __importStar(require("@actions/core"));
 const fs_1 = require("fs");
 const child_process_1 = require("child_process");
 const exec_1 = require("@actions/exec");
+const extract_published_packages_1 = require("./extract-published-packages");
 function execWithOutput(command, args, options) {
     return __awaiter(this, void 0, void 0, function* () {
         let myOutput = '';
@@ -39,16 +40,6 @@ function execWithOutput(command, args, options) {
     });
 }
 exports.execWithOutput = execWithOutput;
-function extractPublishedPackages(line) {
-    let newTagRegex = /New tag:\s+(@[^/]+\/[^@]+|[^/]+)@([^\s]+)/;
-    let match = line.match(newTagRegex);
-    if (match === null) {
-        let npmOutRegex = /\+\s+(@[^/]+\/[^@]+|[^/]+)@([^\s]+)/;
-        match = line.match(npmOutRegex);
-    }
-    core.info(`Matching in line content "${line}", result is: "${match}"`);
-    return match;
-}
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -71,14 +62,12 @@ function run() {
                 let [publishCommand, ...publishArgs] = script.split(/\s+/);
                 let changesetPublishOutput = yield execWithOutput(publishCommand, publishArgs, { cwd: process.cwd() });
                 for (let line of changesetPublishOutput.stdout.split('\n')) {
-                    const match = extractPublishedPackages(line);
+                    const match = extract_published_packages_1.extractPublishedPackages(line);
+                    core.info(`Matching in line content "${line}", result is: "${match}"`);
                     if (match === null) {
                         continue;
                     }
-                    releasedPackages.push({
-                        name: match[1],
-                        version: match[2]
-                    });
+                    releasedPackages.push(match);
                 }
                 const publishedAsString = releasedPackages
                     .map(t => `${t.name}@${t.version}`)

--- a/src/extract-published-packages.ts
+++ b/src/extract-published-packages.ts
@@ -1,0 +1,17 @@
+export function extractPublishedPackages(line: string): { name: string, version: string } | null {
+  let newTagRegex = /New tag:\s+(@[^/]+\/[^@]+|[^/]+)@([^\s]+)/
+  let match = line.match(newTagRegex)
+  
+  if (match === null) {
+      let npmOutRegex = /\+?\s+(@[^/]+\/[^@]+|[^/]+)@([^\s]+)/
+      match = line.match(npmOutRegex)
+  }
+
+  
+  if (match) {
+    const [, name, version] = match
+    return { name, version }
+  }
+
+  return null
+}


### PR DESCRIPTION
The current implementation of the logic did not properly extract the package name and version from the following output:

```
🦋  warn ===============================IMPORTANT!===============================
🦋  warn Packages will be released under the alpha tag
🦋  warn ----------------------------------------------------------------------
🦋  info npm info bob-the-bundler
🦋  info bob-the-bundler is being published because our local version (1.8.0-canary-17052a5.0) has not been published on npm
🦋  info Publishing "bob-the-bundler" at "1.8.0-canary-17052a5.0"
🦋  success packages published successfully:
🦋  bob-the-bundler@1.8.0-canary-17052a5.0
🦋  Creating git tag...
🦋  New tag:  v1.8.0-canary-17052a5.0
```

This behavior was discovered in the following pull request: https://github.com/kamilkisiela/bob/pull/46 (GitHub Action Run: https://github.com/kamilkisiela/bob/runs/6826120652?check_suite_focus=true)

_____


This PR adds a small test suite for all the various outputs the changeset CLI can provide.