### PR TITLE
feat: add table struture to released packages

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -62,7 +62,7 @@ function run() {
                 let [publishCommand, ...publishArgs] = script.split(/\s+/);
                 let changesetPublishOutput = yield execWithOutput(publishCommand, publishArgs, { cwd: process.cwd() });
                 if (changesetPublishOutput.code !== 0) {
-                    throw new Error("Changeset command exited with non-zero code. Please check the output and fix the issue.");
+                    throw new Error('Changeset command exited with non-zero code. Please check the output and fix the issue.');
                 }
                 for (let line of changesetPublishOutput.stdout.split('\n')) {
                     const match = extract_published_packages_1.extractPublishedPackages(line);
@@ -73,7 +73,7 @@ function run() {
                     releasedPackages.push(match);
                 }
                 const publishedAsString = releasedPackages
-                    .map(t => `${t.name}@${t.version}`)
+                    .map(t => `${t.name} | ${t.version}`)
                     .join('\n');
                 const released = releasedPackages.length > 0;
                 if (released) {
@@ -83,7 +83,7 @@ function run() {
                     core.info(`No packages were published...`);
                 }
                 core.setOutput('released', released.toString());
-                core.setOutput('changesetsPublishedPackages', publishedAsString);
+                core.setOutput('changesetsPublishedPackages', `| Package | Version |\n|------|---------|\n${publishedAsString}\n`);
             }
             else {
                 try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,7 +59,9 @@ async function run(): Promise<void> {
       )
 
       if (changesetPublishOutput.code !== 0) {
-        throw new Error("Changeset command exited with non-zero code. Please check the output and fix the issue.")
+        throw new Error(
+          'Changeset command exited with non-zero code. Please check the output and fix the issue.'
+        )
       }
 
       for (let line of changesetPublishOutput.stdout.split('\n')) {
@@ -73,7 +75,7 @@ async function run(): Promise<void> {
       }
 
       const publishedAsString = releasedPackages
-        .map(t => `${t.name}@${t.version}`)
+        .map(t => `${t.name} | ${t.version}`)
         .join('\n')
 
       const released = releasedPackages.length > 0
@@ -86,7 +88,10 @@ async function run(): Promise<void> {
         core.info(`No packages were published...`)
       }
       core.setOutput('released', released.toString())
-      core.setOutput('changesetsPublishedPackages', publishedAsString)
+      core.setOutput(
+        'changesetsPublishedPackages',
+        `| Package | Version |\n|------|---------|\n${publishedAsString}\n`
+      )
     } else {
       try {
         unlinkSync('out.txt')


### PR DESCRIPTION
instead of `name@version` show in makrdown table format

**Current**
![image](https://user-images.githubusercontent.com/44710980/181838704-7a52c6ff-410d-4675-8cd6-fffe55fa81e0.png)

**Once we release this change**
![image](https://user-images.githubusercontent.com/44710980/181838715-fd7520d5-5524-4499-86ca-7e92527226e1.png)

closes https://github.com/the-guild-org/external-board-tasks/issues/98
